### PR TITLE
fix(location): InitializeAsync never called on app launch

### DIFF
--- a/AuroraFix/ViewModels/MainPageViewModel.cs
+++ b/AuroraFix/ViewModels/MainPageViewModel.cs
@@ -50,35 +50,25 @@ public partial class MainPageViewModel : BaseViewModel
         IsDataLoaded = true;
     }
 
-    // Called from MainPage.OnAppearing so startup exceptions are surfaced properly.
-    public Task InitializeAsync()
+    // Called from MainPage.OnAppearing (main thread) — do NOT wrap in Task.Run,
+    // as Permissions.RequestAsync must be called from the main thread on Android.
+    public async Task InitializeAsync()
     {
-        _ = Task.Run(async () =>
+        try
         {
-            try
-            {
-                string? city = await TryGetCityFromGpsAsync();
-                city ??= await TryGetCityFromIpAsync();
+            string? city = await TryGetCityFromGpsAsync();
+            city ??= await TryGetCityFromIpAsync();
 
-                if (!string.IsNullOrWhiteSpace(city))
-                {
-                    MainThread.BeginInvokeOnMainThread(() =>
-                    {
-                        if (string.IsNullOrWhiteSpace(CityName) && !IsBusy)
-                        {
-                            CityName = city;
-                            SearchCityCommand.Execute(null);
-                        }
-                    });
-                }
-            }
-            catch (Exception ex)
+            if (!string.IsNullOrWhiteSpace(city) && string.IsNullOrWhiteSpace(CityName))
             {
-                System.Diagnostics.Debug.WriteLine($"[LocationDetection] Startup lookup failed: {ex.Message}");
+                CityName = city;
+                await SearchCityAsync();
             }
-        });
-
-        return Task.CompletedTask;
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[LocationDetection] Startup lookup failed: {ex.Message}");
+        }
     }
 
     private static async Task<string?> TryGetCityFromGpsAsync()

--- a/AuroraFix/Views/MainPage.xaml.cs
+++ b/AuroraFix/Views/MainPage.xaml.cs
@@ -2,6 +2,8 @@ namespace AuroraFix.Views;
 
 public partial class MainPage : ContentPage
 {
+    private bool _locationInitialized;
+
     public MainPage(ViewModels.MainPageViewModel viewModel)
     {
         InitializeComponent();
@@ -11,8 +13,9 @@ public partial class MainPage : ContentPage
     protected override async void OnAppearing()
     {
         base.OnAppearing();
-        if (BindingContext is ViewModels.MainPageViewModel vm && !vm.IsDataLoaded)
+        if (!_locationInitialized && BindingContext is ViewModels.MainPageViewModel vm)
         {
+            _locationInitialized = true;
             try
             {
                 await vm.InitializeAsync();


### PR DESCRIPTION
## Bug fixes

### Bug 1 — Auto-location never ran
The ViewModel constructor sets `IsDataLoaded = true`. `OnAppearing` checked `!IsDataLoaded` — always `false` — so `InitializeAsync` was NEVER called. App opened, no city detected, nothing loaded.

**Fix:** Added `_locationInitialized` flag in `MainPage.xaml.cs` to gate first-launch detection correctly.

### Bug 2 — GPS permission request on background thread
`InitializeAsync` wrapped everything in `Task.Run`, then called `Permissions.RequestAsync` from that background thread. Android requires permission dialogs on the main thread — silent failure.

**Fix:** Removed `Task.Run` wrapper. Since `OnAppearing` is already on the main thread, `InitializeAsync` now runs there directly.